### PR TITLE
Fixed some compilation warnings and improved the help message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+
+all: parser.c parser.h steamcurses.c
+	gcc -g -Wall -std=c11 -o steamcurses steamcurses.c parser.c -lmenu -lncurses

--- a/makefile
+++ b/makefile
@@ -1,2 +1,0 @@
-all:
-	gcc -std=c11 -D_GNU_SOURCE -lncurses -lmenu -g -o steamcurses steamcurses.c parser.c 

--- a/parser.c
+++ b/parser.c
@@ -1,9 +1,10 @@
+#define _GNU_SOURCE
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <dirent.h>
 #include "parser.h"
-
 
 char* get_vals(char* str) {
   int start = 0;

--- a/parser.h
+++ b/parser.h
@@ -1,7 +1,10 @@
+
 typedef struct game {
   char* appid;
   char* name;
   int is_wine;
 } game_t;
+
 void parse_manifests(int* size, int* capacity, game_t*** games, char* steam_path, int is_wine);
+
 void sort_games(game_t** games, int size);

--- a/steamcurses.c
+++ b/steamcurses.c
@@ -30,11 +30,11 @@ void print_title(WINDOW* win, char* title) {
 }
 
 void print_help() {
-  printf("Usage:\n");
-  printf("-u --username: Your Steam username\n");
-  printf("-p --steam_path: The path tho your steamapps directory\n");
-  printf("-w --wine_steam_path: The path to your wine steamapps directory\n");
-  printf("-h --help: Print this help page\n");
+  printf("Usage: ./steamcurses -u <username> [options]\n");
+  printf("	-u --username:		your Steam username\n");
+  printf("	-p --steam_path:	the path to your steamapps directory\n");
+  printf("	-w --wine_steam_path:	the path to your wine steamapps directory\n");
+  printf("	-h --help:		print this help message and exit\n");
 }
 
 int print_menu(WINDOW* win, MENU* menu, game_t** games) {

--- a/steamcurses.c
+++ b/steamcurses.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <stdlib.h>
 #include <sys/types.h>
 #include <stdio.h>


### PR DESCRIPTION
While compiling there was some error due to an "implicit declaration of 'asprintf'", which was easily fixed by adding ```#define _GNU_SOURCE``` to the source files.

I also slightly improved the readability of the help message and fixed a small spelling error.